### PR TITLE
Enable multi-feature selection & batch attribute editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cached bounds expand cumulatively as you explore different areas
   - "Zoom to Layer" now works even when you've panned away from viewport-culled layers
 - Comprehensive logging for bounds calculation and zoom operations (temporary, for debugging)
+- Layer click to select all features in `FeatureSelectionControl`
+  - Clicking a layer header now selects all features in that layer
+  - Uses multi-selection system with visual feedback (background highlight and checkmark icons)
+  - Provides quick way to batch-select features for editing
 
 ### Changed
 - **BREAKING**: Changed default padding from 50 pixels to 0 pixels for zoom methods (`ZoomToLayer`, `ZoomToFeature`, `ZoomToSelectedFeatures`)
@@ -33,16 +37,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Invisible layers no longer fetch data when zooming or panning
   - Added visibility checks in `layerNeedsUpdate` and `createLayer` methods
   - Saves bandwidth and reduces unnecessary server load
+- `FeatureSelectionControl` UI improvements
+  - Removed collapsible/expandable layer structure (all features now always visible)
+  - Features render as flat list with left indentation for better visibility
+  - Layer headers are now clickable for selecting all features
+- Multi-selection in `FeatureSelectionControl` now restricted to single layer
+  - Attempting to Ctrl+click a feature from a different layer clears previous selection and starts new selection in the new layer
+  - Prevents mixing features with different schemas in batch editing operations
+  - Provides clear console feedback when this occurs
 
 ### Fixed
 - Fixed MVTLoader deprecation warning by using `loadOptions.mvt.shape` instead of deprecated `options.gis`
 - Fixed bug where invisible layers would still fetch data on viewport changes
 - Fixed excessive padding when zooming to layer bounds
 - Set Parcels layer to `Visible="false"` by default in demo for testing
+- Fixed multi-select attribute editing issues in `FeatureAttributesControl`
+  - Fields missing from some features are now displayed (treated as null values)
+  - All unique fields across all selected features are now shown in the attribute table
+  - Fields with different values now show "(Different values)" text initially
+  - Click on "(Different values)" field to enter edit mode and change value for all selected features
+- Fixed unselect feature issues in `FeatureSelectionControl`
+  - Single feature unselect now correctly removes only that feature (not all features in layer)
+  - Layer clear selection now properly clears only features from that layer
+  - MVT layer clear selection now correctly updates map visual highlighting
+  - JavaScript now stores full feature data with layer associations to support MVT layers
+  - C# state reconciliation ensures UI and map stay in sync after unselect operations
+- Fixed CSS024 validation warning in `FeatureSelectionControl`
+  - Moved inline conditional style logic to helper method `GetFeatureStyle()`
+  - Ensures valid CSS is always generated (no empty strings or trailing semicolons)
 
 ### Updated
 - ParcelsController, TownshipsController, and TownshipExtensionsController to handle viewport padding server-side
 - `buildViewportUrl` in TypeScript to send exact viewport bounds without client-side padding multiplication
+- `FeatureSelectionControl` test selectors to find feature items specifically (with `padding-left: 32px`) instead of any clickable element
+- TypeScript selection tracking in `deckGLView.ts` to store full feature data with layer associations
+  - Added `selectedFeaturesData` Map to track features with their layer IDs
+  - Modified `unselectFeature()` and `clearLayerSelection()` to use stored data
+  - Created `getSelectedFeaturesFromData()` method for universal layer type support
 
 ## [1.0.2] - 2026-01-20
 

--- a/PyroGeoBlazor.DeckGL/Attributes/Components/FeatureAttributesControl.razor
+++ b/PyroGeoBlazor.DeckGL/Attributes/Components/FeatureAttributesControl.razor
@@ -2,12 +2,12 @@
 @using PyroGeoBlazor.DeckGL.Models
 @using System.Text.Json
 
-@if (SelectedFeature != null)
+@if (SelectedFeature != null || (SelectedFeatures != null && SelectedFeatures.Count > 0))
 {
     <div style="padding: 8px;">
         <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-2">
             <MudText Typo="Typo.subtitle2">
-                <strong>Feature Attributes</strong>
+                <strong>@(IsMultiEditMode ? $"Feature Attributes ({SelectedFeatures!.Count} selected)" : "Feature Attributes")</strong>
             </MudText>
             <MudStack Row Spacing="1">
                 @if (IsLocked)
@@ -18,13 +18,13 @@
                         </MudChip>
                     </MudTooltip>
                 }
-                @if (EditContext != null && EditContext.IsDirty)
+                @if ((EditContext != null && EditContext.IsDirty) || (MultiEditContext != null && MultiEditContext.IsDirty))
                 {
                     <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled">
                         Modified
                     </MudChip>
                 }
-                @if (EditContext != null && !EditContext.IsValid)
+                @if ((EditContext != null && !EditContext.IsValid) || (MultiEditContext != null && !MultiEditContext.IsValid))
                 {
                     <MudChip T="string" Size="Size.Small" Color="Color.Error" Variant="Variant.Filled">
                         Invalid
@@ -58,7 +58,7 @@
                             <td style="vertical-align: middle;">
                                 @if (field.IsEditable && !IsLocked)
                                 {
-                                    @RenderEditControl(field)
+                                    @RenderEditableField(field)
                                 }
                                 else
                                 {
@@ -70,7 +70,7 @@
                 </tbody>
             </MudSimpleTable>
 
-            @if (EditContext != null && EditContext.IsDirty && !IsLocked)
+            @if (((EditContext != null && EditContext.IsDirty) || (MultiEditContext != null && MultiEditContext.IsDirty)) && !IsLocked)
             {
                 <MudStack Row Justify="Justify.FlexEnd" Spacing="2" Class="mt-2">
                     <MudButton Size="Size.Small" 
@@ -82,7 +82,7 @@
                     <MudButton Size="Size.Small" 
                                Variant="Variant.Filled" 
                                Color="Color.Primary"
-                               Disabled="@(!EditContext.IsValid)"
+                               Disabled="@(!(EditContext?.IsValid ?? MultiEditContext?.IsValid ?? false))"
                                OnClick="SaveChanges">
                         Save Changes
                     </MudButton>
@@ -107,15 +107,21 @@ else
 }
 
 @code {
-    /// <summary>
-    /// The selected feature to display attributes for
-    /// </summary>
-    [Parameter] public SelectedFeature? SelectedFeature { get; set; }
+/// <summary>
+/// The selected feature to display attributes for (single feature mode)
+/// </summary>
+[Parameter] public SelectedFeature? SelectedFeature { get; set; }
 
-    /// <summary>
-    /// When true, indicates the layer does not allow attribute editing and displays a lock indicator
-    /// </summary>
-    [Parameter] public bool IsLocked { get; set; }
+/// <summary>
+/// List of selected features for batch editing (multi-feature mode)
+/// When set, takes precedence over SelectedFeature parameter
+/// </summary>
+[Parameter] public List<SelectedFeature>? SelectedFeatures { get; set; }
+
+/// <summary>
+/// When true, indicates the layer does not allow attribute editing and displays a lock indicator
+/// </summary>
+[Parameter] public bool IsLocked { get; set; }
 
     /// <summary>
     /// Configuration for editable fields. Defines which fields can be edited and how.
@@ -129,9 +135,9 @@ else
 
     /// <summary>
     /// Event callback invoked when changes are saved.
-    /// Provides the modified fields and their new values.
+    /// Provides either AttributeEditContext (single feature) or MultiFeatureEditContext (batch edit).
     /// </summary>
-    [Parameter] public EventCallback<AttributeEditContext> OnSaveChanges { get; set; }
+    [Parameter] public EventCallback<object> OnSaveChanges { get; set; }
 
     /// <summary>
     /// Event callback invoked when changes are reset.
@@ -159,19 +165,36 @@ else
     );
 
     private AttributeEditContext? EditContext { get; set; }
+    private MultiFeatureEditContext? MultiEditContext { get; set; }
+    
+    // Track which fields are in edit mode for multi-select with different values
+    private readonly HashSet<string> _fieldsInEditMode = new();
+    
+    // Helper property to determine if we're in multi-edit mode
+    private bool IsMultiEditMode => SelectedFeatures != null && SelectedFeatures.Count > 1;
 
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
 
-        // Initialize edit context when feature changes
-        if (SelectedFeature != null && EditableFieldsConfig != null && EditableFieldsConfig.Any())
+        // Initialize edit context based on mode
+        if (IsMultiEditMode)
+        {
+            InitializeMultiEditContext();
+            EditContext = null;
+            _fieldsInEditMode.Clear(); // Reset edit mode tracking when features change
+        }
+        else if (SelectedFeature != null && EditableFieldsConfig != null && EditableFieldsConfig.Any())
         {
             InitializeEditContext();
+            MultiEditContext = null;
+            _fieldsInEditMode.Clear();
         }
         else
         {
             EditContext = null;
+            MultiEditContext = null;
+            _fieldsInEditMode.Clear();
         }
     }
 
@@ -209,6 +232,82 @@ else
         }
     }
 
+    private void InitializeMultiEditContext()
+    {
+        if (SelectedFeatures == null || SelectedFeatures.Count == 0) return;
+
+        MultiEditContext = new MultiFeatureEditContext
+        {
+            Features = SelectedFeatures
+        };
+
+        // Analyze each field to determine if values are common or different across features
+        foreach (var fieldConfig in EditableFieldsConfig ?? [])
+        {
+            var fieldState = AnalyzeFieldAcrossFeatures(fieldConfig.FieldName, fieldConfig.DataType);
+            MultiEditContext.FieldStates[fieldConfig.FieldName] = fieldState;
+        }
+    }
+
+    private FieldValueState AnalyzeFieldAcrossFeatures(string fieldName, AttributeDataType dataType)
+    {
+        if (SelectedFeatures == null || SelectedFeatures.Count == 0)
+        {
+            return new FieldValueState { AllNull = true, CommonValue = null };
+        }
+
+        var values = new List<object?>();
+        
+        foreach (var feature in SelectedFeatures)
+        {
+            object? value = null;
+            
+            // Handle "id" at root level
+            if (fieldName.Equals("id", StringComparison.OrdinalIgnoreCase))
+            {
+                if (feature.Feature.TryGetProperty("id", out var idValue))
+                {
+                    value = ConvertJsonElementToObject(idValue, dataType);
+                }
+            }
+            // Handle properties
+            else if (feature.Feature.TryGetProperty("properties", out var properties))
+            {
+                if (properties.TryGetProperty(fieldName, out var propValue))
+                {
+                    value = ConvertJsonElementToObject(propValue, dataType);
+                }
+            }
+            
+            values.Add(value);
+        }
+
+        // Check if all values are null
+        if (values.All(v => v == null))
+        {
+            return new FieldValueState { AllNull = true, CommonValue = null, HasDifferentValues = false };
+        }
+
+        // Check if all non-null values are the same
+        var nonNullValues = values.Where(v => v != null).ToList();
+        if (nonNullValues.Count == 0)
+        {
+            return new FieldValueState { AllNull = true, CommonValue = null, HasDifferentValues = false };
+        }
+
+        var firstValue = nonNullValues[0];
+        var allSame = nonNullValues.All(v => Equals(v, firstValue));
+
+        if (allSame && values.All(v => v != null || values.Count(x => x == null) == values.Count))
+        {
+            // All values are the same (including all null case handled above)
+            return new FieldValueState { HasDifferentValues = false, CommonValue = firstValue, AllNull = false };
+        }
+        
+        // Values differ
+        return new FieldValueState { HasDifferentValues = true, CommonValue = null, AllNull = false };
+    }
+
     private record DisplayableField(
         string FieldName,
         string DisplayName,
@@ -219,7 +318,16 @@ else
 
     private List<DisplayableField> GetDisplayableFields()
     {
-        if (SelectedFeature == null)
+        if (IsMultiEditMode && SelectedFeatures != null && SelectedFeatures.Count > 0)
+        {
+            // In multi-edit mode, collect all unique fields across all features
+            return GetDisplayableFieldsForMultipleFeatures();
+        }
+        
+        // Single-edit mode: Use the single feature
+        var referenceFeature = SelectedFeature;
+        
+        if (referenceFeature == null)
             return [];
 
         var fields = new List<DisplayableField>();
@@ -227,7 +335,7 @@ else
         var configuredFields = EditableFieldsConfig?.ToDictionary(f => f.FieldName, StringComparer.OrdinalIgnoreCase) ?? [];
 
         // Add feature ID if available (it's at root level in GeoJSON, not in properties)
-        if (SelectedFeature.Feature.TryGetProperty("id", out var idElement) && !excludedProps.Contains("id"))
+        if (referenceFeature.Feature.TryGetProperty("id", out var idElement) && !excludedProps.Contains("id"))
         {
             if (configuredFields.TryGetValue("id", out var idConfig))
             {
@@ -253,7 +361,7 @@ else
         }
 
         // Get properties from feature
-        if (SelectedFeature.Feature.TryGetProperty("properties", out var properties))
+        if (referenceFeature.Feature.TryGetProperty("properties", out var properties))
         {
             foreach (var property in properties.EnumerateObject())
             {
@@ -292,8 +400,80 @@ else
             .ToList();
     }
 
+    private List<DisplayableField> GetDisplayableFieldsForMultipleFeatures()
+    {
+        if (SelectedFeatures == null || SelectedFeatures.Count == 0)
+            return [];
+
+        var fields = new List<DisplayableField>();
+        var excludedProps = new HashSet<string>(ExcludedProperties ?? [], StringComparer.OrdinalIgnoreCase);
+        var configuredFields = EditableFieldsConfig?.ToDictionary(f => f.FieldName, StringComparer.OrdinalIgnoreCase) ?? [];
+        var allFieldNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Collect all unique field names from all features
+        foreach (var feature in SelectedFeatures)
+        {
+            // Check for "id" at root level
+            if (feature.Feature.TryGetProperty("id", out _))
+            {
+                allFieldNames.Add("id");
+            }
+
+            // Collect property names
+            if (feature.Feature.TryGetProperty("properties", out var properties))
+            {
+                foreach (var property in properties.EnumerateObject())
+                {
+                    if (!excludedProps.Contains(property.Name))
+                    {
+                        allFieldNames.Add(property.Name);
+                    }
+                }
+            }
+        }
+
+        // Build displayable fields for all collected field names
+        foreach (var fieldName in allFieldNames)
+        {
+            if (configuredFields.TryGetValue(fieldName, out var config))
+            {
+                fields.Add(new DisplayableField(
+                    fieldName,
+                    config.EffectiveDisplayName,
+                    !config.IsReadOnly && !IsLocked,
+                    config,
+                    config.HelpText
+                ));
+            }
+            else
+            {
+                // Show as read-only if no config
+                fields.Add(new DisplayableField(
+                    fieldName,
+                    fieldName,
+                    false,
+                    null,
+                    null
+                ));
+            }
+        }
+
+        // Sort by order if specified, otherwise alphabetically
+        return fields
+            .OrderBy(f => f.Config?.Order ?? int.MaxValue)
+            .ThenBy(f => f.DisplayName)
+            .ToList();
+    }
+
     private string GetFieldDisplayValue(string fieldName)
     {
+        // Multi-edit mode: Use MultiEditContext
+        if (IsMultiEditMode && MultiEditContext != null)
+        {
+            return MultiEditContext.GetDisplayValue(fieldName);
+        }
+
+        // Single-edit mode: Use EditContext
         if (EditContext != null && EditContext.CurrentValues.TryGetValue(fieldName, out var value))
         {
             return FormatValue(value);
@@ -330,6 +510,48 @@ else
         };
     }
 
+    private RenderFragment RenderEditableField(DisplayableField field)
+    {
+        return builder =>
+        {
+            // In multi-edit mode with different values, show text until clicked
+            if (IsMultiEditMode && MultiEditContext != null &&
+                MultiEditContext.FieldStates.TryGetValue(field.FieldName, out var fieldState) &&
+                fieldState.HasDifferentValues &&
+                !_fieldsInEditMode.Contains(field.FieldName))
+            {
+                // Show "(Different values)" text with click handler
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "style", "cursor: pointer; padding: 8px; border: 1px solid transparent; border-radius: 4px;");
+                builder.AddAttribute(2, "onmouseover", "this.style.borderColor='var(--mud-palette-divider)'");
+                builder.AddAttribute(3, "onmouseout", "this.style.borderColor='transparent'");
+                builder.AddAttribute(4, "onclick", EventCallback.Factory.Create(this, () => EnterEditMode(field.FieldName)));
+                
+                builder.OpenComponent<MudText>(5);
+                builder.AddAttribute(6, "Typo", Typo.body2);
+                builder.AddAttribute(7, "Color", Color.Secondary);
+                builder.AddAttribute(8, "ChildContent", (RenderFragment)(textBuilder =>
+                {
+                    textBuilder.AddContent(0, "(Different values)");
+                }));
+                builder.CloseComponent();
+                
+                builder.CloseElement();
+            }
+            else
+            {
+                // Show edit control
+                RenderEditControl(field).Invoke(builder);
+            }
+        };
+    }
+
+    private void EnterEditMode(string fieldName)
+    {
+        _fieldsInEditMode.Add(fieldName);
+        StateHasChanged();
+    }
+
     private RenderFragment RenderEditControl(DisplayableField field)
     {
         return builder =>
@@ -337,9 +559,42 @@ else
             if (field.Config == null) return;
 
             var config = field.Config;
-            var currentValue = EditContext?.GetCurrentValue(field.FieldName);
-            var hasError = EditContext?.ValidationErrors.ContainsKey(field.FieldName) == true;
-            var errorText = hasError ? EditContext!.ValidationErrors[field.FieldName] : null;
+            
+            // Get current value and error state from appropriate context
+            object? currentValue;
+            bool hasError;
+            string? errorText;
+            
+            if (IsMultiEditMode && MultiEditContext != null)
+            {
+                currentValue = MultiEditContext.GetCurrentValue(field.FieldName);
+                
+                // If not modified, check if we should show a placeholder for different values
+                if (currentValue == null && 
+                    MultiEditContext.FieldStates.TryGetValue(field.FieldName, out var fieldState) &&
+                    fieldState.HasDifferentValues)
+                {
+                    // Will be handled by placeholder in control rendering
+                }
+                else if (currentValue == null && 
+                         MultiEditContext.FieldStates.TryGetValue(field.FieldName, out fieldState))
+                {
+                    currentValue = fieldState.CommonValue;
+                }
+                
+                hasError = MultiEditContext.ValidationErrors.ContainsKey(field.FieldName);
+                errorText = hasError ? MultiEditContext.ValidationErrors[field.FieldName] : null;
+            }
+            else if (EditContext != null)
+            {
+                currentValue = EditContext.GetCurrentValue(field.FieldName);
+                hasError = EditContext.ValidationErrors.ContainsKey(field.FieldName);
+                errorText = hasError ? EditContext.ValidationErrors[field.FieldName] : null;
+            }
+            else
+            {
+                return; // No context available
+            }
 
             // Check if a custom renderer is provided for this field
             if (CustomFieldRenderers?.TryGetValue(field.FieldName, out var customRenderer) == true)
@@ -399,10 +654,21 @@ else
 
     private void RenderTextInput(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder, DisplayableField field, object? currentValue, bool hasError, string? errorText)
     {
+        // Determine placeholder text for multi-edit mode
+        string? placeholder = field.Config?.Placeholder;
+        
+        if (IsMultiEditMode && MultiEditContext != null && 
+            currentValue == null && 
+            MultiEditContext.FieldStates.TryGetValue(field.FieldName, out var fieldState) &&
+            fieldState.HasDifferentValues)
+        {
+            placeholder = "(Different values)";
+        }
+        
         builder.OpenComponent<MudTextField<string>>(0);
         builder.AddAttribute(1, "Value", currentValue?.ToString() ?? string.Empty);
         builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, value => OnFieldChanged(field.FieldName, value)));
-        builder.AddAttribute(3, "Placeholder", field.Config?.Placeholder);
+        builder.AddAttribute(3, "Placeholder", placeholder);
         builder.AddAttribute(4, "Required", field.Config?.IsRequired ?? false);
         builder.AddAttribute(5, "MaxLength", field.Config?.MaxLength);
         builder.AddAttribute(6, "Error", hasError);
@@ -515,26 +781,47 @@ else
 
     private void OnFieldChanged(string fieldName, object? value)
     {
-        if (EditContext == null) return;
-
-        EditContext.SetCurrentValue(fieldName, value);
-        ValidateField(fieldName, value);
+        if (IsMultiEditMode && MultiEditContext != null)
+        {
+            MultiEditContext.SetCurrentValue(fieldName, value);
+            ValidateField(fieldName, value);
+        }
+        else if (EditContext != null)
+        {
+            EditContext.SetCurrentValue(fieldName, value);
+            ValidateField(fieldName, value);
+        }
+        
         StateHasChanged();
     }
 
     private void ValidateField(string fieldName, object? value)
     {
-        if (EditContext == null) return;
-
         var config = EditableFieldsConfig?.FirstOrDefault(f => f.FieldName.Equals(fieldName, StringComparison.OrdinalIgnoreCase));
         if (config == null) return;
 
-        EditContext.ClearValidationError(fieldName);
+        // Clear errors in appropriate context
+        if (IsMultiEditMode && MultiEditContext != null)
+        {
+            MultiEditContext.ClearValidationError(fieldName);
+        }
+        else if (EditContext != null)
+        {
+            EditContext.ClearValidationError(fieldName);
+        }
 
         // Required validation
         if (config.IsRequired && (value == null || (value is string str && string.IsNullOrWhiteSpace(str))))
         {
-            EditContext.SetValidationError(fieldName, $"{config.EffectiveDisplayName} is required");
+            var errorMsg = $"{config.EffectiveDisplayName} is required";
+            if (IsMultiEditMode && MultiEditContext != null)
+            {
+                MultiEditContext.SetValidationError(fieldName, errorMsg);
+            }
+            else if (EditContext != null)
+            {
+                EditContext.SetValidationError(fieldName, errorMsg);
+            }
             return;
         }
 
@@ -543,7 +830,15 @@ else
         {
             if (!codedDomain.CodedValues.Any(cv => Equals(cv.Code, value)))
             {
-                EditContext.SetValidationError(fieldName, $"Invalid value for {config.EffectiveDisplayName}");
+                var errorMsg = $"Invalid value for {config.EffectiveDisplayName}";
+                if (IsMultiEditMode && MultiEditContext != null)
+                {
+                    MultiEditContext.SetValidationError(fieldName, errorMsg);
+                }
+                else if (EditContext != null)
+                {
+                    EditContext.SetValidationError(fieldName, errorMsg);
+                }
                 return;
             }
         }
@@ -553,7 +848,15 @@ else
             var numValue = Convert.ToDouble(value);
             if (numValue < rangeDomain.MinValue || numValue > rangeDomain.MaxValue)
             {
-                EditContext.SetValidationError(fieldName, $"{config.EffectiveDisplayName} must be between {rangeDomain.MinValue} and {rangeDomain.MaxValue}");
+                var errorMsg = $"{config.EffectiveDisplayName} must be between {rangeDomain.MinValue} and {rangeDomain.MaxValue}";
+                if (IsMultiEditMode && MultiEditContext != null)
+                {
+                    MultiEditContext.SetValidationError(fieldName, errorMsg);
+                }
+                else if (EditContext != null)
+                {
+                    EditContext.SetValidationError(fieldName, errorMsg);
+                }
                 return;
             }
         }
@@ -561,20 +864,41 @@ else
         // Max length validation for strings
         if (config.MaxLength.HasValue && value is string stringValue && stringValue.Length > config.MaxLength.Value)
         {
-            EditContext.SetValidationError(fieldName, $"{config.EffectiveDisplayName} cannot exceed {config.MaxLength.Value} characters");
+            var errorMsg = $"{config.EffectiveDisplayName} cannot exceed {config.MaxLength.Value} characters";
+            if (IsMultiEditMode && MultiEditContext != null)
+            {
+                MultiEditContext.SetValidationError(fieldName, errorMsg);
+            }
+            else if (EditContext != null)
+            {
+                EditContext.SetValidationError(fieldName, errorMsg);
+            }
         }
     }
 
     private async Task SaveChanges()
     {
-        if (EditContext == null || !EditContext.IsValid) return;
-
-        await OnSaveChanges.InvokeAsync(EditContext);
+        if (IsMultiEditMode && MultiEditContext != null && MultiEditContext.IsValid)
+        {
+            await OnSaveChanges.InvokeAsync(MultiEditContext);
+        }
+        else if (EditContext != null && EditContext.IsValid)
+        {
+            await OnSaveChanges.InvokeAsync(EditContext);
+        }
     }
 
     private async Task ResetChanges()
     {
-        EditContext?.ResetAll();
+        if (IsMultiEditMode && MultiEditContext != null)
+        {
+            MultiEditContext.ResetAll();
+        }
+        else if (EditContext != null)
+        {
+            EditContext.ResetAll();
+        }
+        
         await OnResetChanges.InvokeAsync();
         StateHasChanged();
     }

--- a/PyroGeoBlazor.DeckGL/Attributes/Components/FeatureSelectionControl.razor
+++ b/PyroGeoBlazor.DeckGL/Attributes/Components/FeatureSelectionControl.razor
@@ -17,80 +17,84 @@
             <MudList T="string" Dense>
                 @foreach (var layerGroup in GetGroupedFeatures())
                 {
-                    <MudListItem T="string" Expanded>
-                        <ChildContent>
-                            <div @oncontextmenu="@(e => OpenLayerContextMenu(e, layerGroup.LayerId))"
+                    @* Layer header - clickable to select all features *@
+                    <MudListItem T="string" @onclick="@(() => OnLayerClick(layerGroup.LayerId))">
+                        <div @oncontextmenu="@(e => OpenLayerContextMenu(e, layerGroup.LayerId))"
+                             @oncontextmenu:preventDefault="true"
+                             style="cursor: pointer; padding: 8px 0;">
+                            <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                                <MudText Typo="Typo.subtitle2">
+                                    <strong>@layerGroup.LayerId</strong> (@layerGroup.Features.Count)
+                                </MudText>
+                            </MudStack>
+                        </div>
+                        
+                        <MudPopover Open="@(currentLayerContextMenu == layerGroup.LayerId)" 
+                                    Fixed="true" 
+                                    AnchorOrigin="Origin.TopLeft"
+                                    TransformOrigin="Origin.TopLeft"
+                                    Style="@GetPopoverStyle()">
+                            <MudList Dense="true" Style="min-width: 150px;">
+                                <MudListItem OnClick="@(async () => { await OnLayerZoomTo(layerGroup.LayerId); CloseContextMenu(); })" 
+                                             Icon="@Icons.Material.Filled.ZoomIn">
+                                    Zoom to Layer
+                                </MudListItem>
+                                <MudListItem OnClick="@(async () => { await OnLayerClearSelection(layerGroup.LayerId); CloseContextMenu(); })" 
+                                             Icon="@Icons.Material.Filled.Clear">
+                                    Clear Selection
+                                </MudListItem>
+                            </MudList>
+                        </MudPopover>
+                    </MudListItem>
+                    
+                    @* Feature items - always visible (no nested list) *@
+                    @foreach (var feature in layerGroup.Features)
+                    {
+                        <MudListItem T="string" Style="padding-left: 32px;">
+                            <div @oncontextmenu="@(e => OpenFeatureContextMenu(e, feature, layerGroup.LayerId))"
                                  @oncontextmenu:preventDefault="true"
-                                 style="cursor: context-menu;">
+                                 @onclick="@(e => OnFeatureClickInternal(feature, e))"
+                                 style="@GetFeatureStyle(feature, layerGroup.LayerId)">
                                 <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-                                    <MudText Typo="Typo.subtitle2">
-                                        <strong>@layerGroup.LayerId</strong> (@layerGroup.Features.Count)
+                                    <MudText Typo="Typo.body2" Style="flex: 1;">
+                                        @GetFeatureDisplayName(feature, layerGroup.LayerId)
                                     </MudText>
+                                    @if (IsFeatureMultiSelected(feature, layerGroup.LayerId))
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Small" Color="Color.Primary" />
+                                    }
                                 </MudStack>
                             </div>
                             
-                            <MudPopover Open="@(currentLayerContextMenu == layerGroup.LayerId)" 
-                                        Fixed="true" 
+                            <MudPopover Open="@IsFeatureContextMenuOpen(feature, layerGroup.LayerId)" 
+                                        Fixed="true"
                                         AnchorOrigin="Origin.TopLeft"
                                         TransformOrigin="Origin.TopLeft"
                                         Style="@GetPopoverStyle()">
                                 <MudList Dense="true" Style="min-width: 150px;">
-                                    <MudListItem OnClick="@(async () => { await OnLayerZoomTo(layerGroup.LayerId); CloseContextMenu(); })" 
-                                                 Icon="@Icons.Material.Filled.ZoomIn">
-                                        Zoom to Layer
+                                    <MudListItem OnClick="@(async () => { await OnFeatureFlash(feature, layerGroup.LayerId); CloseContextMenu(); })" 
+                                                 Icon="@Icons.Material.Filled.FlashOn">
+                                        Flash
                                     </MudListItem>
-                                    <MudListItem OnClick="@(async () => { await OnLayerClearSelection(layerGroup.LayerId); CloseContextMenu(); })" 
-                                                 Icon="@Icons.Material.Filled.Clear">
-                                        Clear Selection
+                                    <MudListItem OnClick="@(async () => { await OnFeatureZoomTo(feature, layerGroup.LayerId); CloseContextMenu(); })" 
+                                                 Icon="@Icons.Material.Filled.ZoomIn">
+                                        Zoom to
+                                    </MudListItem>
+                                    <MudListItem OnClick="@(async () => { await OnFeatureUnselect(feature, layerGroup.LayerId); CloseContextMenu(); })" 
+                                                 Icon="@Icons.Material.Filled.RemoveCircleOutline">
+                                        Unselect
                                     </MudListItem>
                                 </MudList>
                             </MudPopover>
-                        </ChildContent>
-                        <NestedList>
-                            @foreach (var feature in layerGroup.Features)
-                            {
-                                <MudListItem T="string">
-                                    <div @oncontextmenu="@(e => OpenFeatureContextMenu(e, feature, layerGroup.LayerId))"
-                                         @oncontextmenu:preventDefault="true"
-                                         @onclick="@(() => OnFeatureClickInternal(feature))"
-                                         style="cursor: pointer;">
-                                        <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-                                            <MudText Typo="Typo.body2" Style="flex: 1;">
-                                                @GetFeatureDisplayName(feature, layerGroup.LayerId)
-                                            </MudText>
-                                        </MudStack>
-                                    </div>
-                                    
-                                    <MudPopover Open="@IsFeatureContextMenuOpen(feature, layerGroup.LayerId)" 
-                                                Fixed="true"
-                                                AnchorOrigin="Origin.TopLeft"
-                                                TransformOrigin="Origin.TopLeft"
-                                                Style="@GetPopoverStyle()">
-                                        <MudList Dense="true" Style="min-width: 150px;">
-                                            <MudListItem OnClick="@(async () => { await OnFeatureFlash(feature, layerGroup.LayerId); CloseContextMenu(); })" 
-                                                         Icon="@Icons.Material.Filled.FlashOn">
-                                                Flash
-                                            </MudListItem>
-                                            <MudListItem OnClick="@(async () => { await OnFeatureZoomTo(feature, layerGroup.LayerId); CloseContextMenu(); })" 
-                                                         Icon="@Icons.Material.Filled.ZoomIn">
-                                                Zoom to
-                                            </MudListItem>
-                                            <MudListItem OnClick="@(async () => { await OnFeatureUnselect(feature, layerGroup.LayerId); CloseContextMenu(); })" 
-                                                         Icon="@Icons.Material.Filled.RemoveCircleOutline">
-                                                Unselect
-                                            </MudListItem>
-                                        </MudList>
-                                    </MudPopover>
-                                </MudListItem>
-                            }
-                        </NestedList>
-                    </MudListItem>
+                        </MudListItem>
+                    }
                 }
             </MudList>
         </div>
         
         <div style="flex: 1 1 50%; overflow-y: auto; overflow-x: hidden; min-height: 0; border-top: 1px solid var(--mud-palette-divider);">
             <FeatureAttributesControl SelectedFeature="@clickedFeature" 
+                                     SelectedFeatures="@_multiSelectedFeatureList"
                                      ExcludedProperties="@GetEffectiveExcludedProperties()"
                                      IsLocked="@IsClickedFeatureLocked()"
                                      EditableFieldsConfig="@GetEditableFieldsConfig()"

--- a/PyroGeoBlazor.DeckGL/Attributes/Models/MultiFeatureEditContext.cs
+++ b/PyroGeoBlazor.DeckGL/Attributes/Models/MultiFeatureEditContext.cs
@@ -1,0 +1,148 @@
+namespace PyroGeoBlazor.DeckGL.Models;
+
+using System.Text.Json;
+
+/// <summary>
+/// Tracks attribute changes for multiple features being edited together.
+/// Handles display of common values vs. different values across the selected features.
+/// </summary>
+public class MultiFeatureEditContext
+{
+    /// <summary>
+    /// List of all features being edited together.
+    /// </summary>
+    public List<SelectedFeature> Features { get; set; } = [];
+
+    /// <summary>
+    /// Dictionary of field names to their common/aggregated values.
+    /// Value is null if the field has different values across features.
+    /// </summary>
+    public Dictionary<string, FieldValueState> FieldStates { get; set; } = [];
+
+    /// <summary>
+    /// Dictionary of field names to their current (possibly modified) values.
+    /// When a field is edited, all features will receive this value on save.
+    /// </summary>
+    public Dictionary<string, object?> CurrentValues { get; set; } = [];
+
+    /// <summary>
+    /// Dictionary of field names to their validation errors (if any).
+    /// Key is field name, value is error message.
+    /// </summary>
+    public Dictionary<string, string> ValidationErrors { get; set; } = [];
+
+    /// <summary>
+    /// Whether any fields have been modified.
+    /// </summary>
+    public bool IsDirty => CurrentValues.Count > 0;
+
+    /// <summary>
+    /// Whether the current state is valid (no validation errors).
+    /// </summary>
+    public bool IsValid => ValidationErrors.Count == 0;
+
+    /// <summary>
+    /// Gets the modified fields (field names that have been changed).
+    /// </summary>
+    public IEnumerable<string> ModifiedFields => CurrentValues.Keys;
+
+    /// <summary>
+    /// Gets the current value of a field, or null if not found.
+    /// </summary>
+    public object? GetCurrentValue(string fieldName)
+    {
+        return CurrentValues.TryGetValue(fieldName, out var value) ? value : null;
+    }
+
+    /// <summary>
+    /// Sets the current value of a field (marks it as modified).
+    /// </summary>
+    public void SetCurrentValue(string fieldName, object? value)
+    {
+        CurrentValues[fieldName] = value;
+    }
+
+    /// <summary>
+    /// Adds or updates a validation error for a field.
+    /// </summary>
+    public void SetValidationError(string fieldName, string errorMessage)
+    {
+        ValidationErrors[fieldName] = errorMessage;
+    }
+
+    /// <summary>
+    /// Clears validation error for a field.
+    /// </summary>
+    public void ClearValidationError(string fieldName)
+    {
+        ValidationErrors.Remove(fieldName);
+    }
+
+    /// <summary>
+    /// Resets all fields to their original state (clears modifications).
+    /// </summary>
+    public void ResetAll()
+    {
+        CurrentValues.Clear();
+        ValidationErrors.Clear();
+    }
+
+    /// <summary>
+    /// Gets the display value for a field, considering whether it's been modified
+    /// or if it has different values across features.
+    /// </summary>
+    public string GetDisplayValue(string fieldName)
+    {
+        // If modified, show the new value
+        if (CurrentValues.TryGetValue(fieldName, out var modifiedValue))
+        {
+            return FormatValue(modifiedValue);
+        }
+
+        // If not modified, check if values differ
+        if (FieldStates.TryGetValue(fieldName, out var state))
+        {
+            if (state.HasDifferentValues)
+            {
+                return "(Different values)";
+            }
+            return FormatValue(state.CommonValue);
+        }
+
+        return string.Empty;
+    }
+
+    private string FormatValue(object? value)
+    {
+        return value switch
+        {
+            null => string.Empty,
+            bool b => b ? "Yes" : "No",
+            DateTime dt => dt.ToString("yyyy-MM-dd HH:mm:ss"),
+            DateOnly d => d.ToString("yyyy-MM-dd"),
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+}
+
+/// <summary>
+/// Represents the state of a field's values across multiple features.
+/// </summary>
+public class FieldValueState
+{
+    /// <summary>
+    /// Whether the field has different values across the selected features.
+    /// </summary>
+    public bool HasDifferentValues { get; set; }
+
+    /// <summary>
+    /// The common value if all features have the same value (or all null).
+    /// Null if HasDifferentValues is true.
+    /// </summary>
+    public object? CommonValue { get; set; }
+
+    /// <summary>
+    /// Whether all features have null values for this field.
+    /// </summary>
+    public bool AllNull { get; set; }
+}

--- a/PyroGeoBlazor.Demo/Components/Pages/MapWorkspacePage.razor
+++ b/PyroGeoBlazor.Demo/Components/Pages/MapWorkspacePage.razor
@@ -275,17 +275,8 @@
         StateHasChanged();
     }
 
-    private Task OnAttributesSaved((string LayerId, string FeatureId, AttributeEditContext EditContext) data)
+    private Task OnAttributesSaved(object data)
     {
-        Console.WriteLine($"💾 Saving attributes for feature {data.FeatureId} in layer {data.LayerId}");
-        Console.WriteLine($"   Modified fields: {string.Join(", ", data.EditContext.ModifiedFields)}");
-
-        foreach (var fieldName in data.EditContext.ModifiedFields)
-        {
-            var newValue = data.EditContext.GetCurrentValue(fieldName);
-            Console.WriteLine($"   - {fieldName}: {newValue}");
-        }
-
         // TODO: Implement actual save logic here
         // This would typically involve:
         // 1. Calling a backend API to persist the changes

--- a/tests/PyroGeoBlazor.DeckGL.Tests.Unit/Components/FeatureAttributesControlTests.cs
+++ b/tests/PyroGeoBlazor.DeckGL.Tests.Unit/Components/FeatureAttributesControlTests.cs
@@ -242,4 +242,204 @@ public class FeatureAttributesControlTests : MudBlazorTestContext
         // Assert
         cut.Markup.Should().Contain("No properties available");
     }
+
+    [Fact]
+    public void FeatureAttributesControl_MultiEdit_ShowsFeatureCount()
+    {
+        // Arrange
+        var feature1Json = """{"type": "Feature", "id": "f1", "properties": {"name": "Feature 1"}}""";
+        var feature2Json = """{"type": "Feature", "id": "f2", "properties": {"name": "Feature 2"}}""";
+        
+        var features = new List<SelectedFeature>
+        {
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature1Json) },
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature2Json) }
+        };
+
+        // Act
+        var cut = RenderWithMud<FeatureAttributesControl>(parameters => parameters
+            .Add(p => p.SelectedFeatures, features));
+
+        // Assert
+        cut.Markup.Should().Contain("(2 selected)", "should show count of selected features in header");
+    }
+
+    [Fact]
+    public void FeatureAttributesControl_MultiEdit_ShowsCommonValue()
+    {
+        // Arrange
+        var feature1Json = """{"type": "Feature", "properties": {"status": "active", "name": "F1"}}""";
+        var feature2Json = """{"type": "Feature", "properties": {"status": "active", "name": "F2"}}""";
+        
+        var features = new List<SelectedFeature>
+        {
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature1Json) },
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature2Json) }
+        };
+
+        var editableFields = new List<AttributeFieldConfig>
+        {
+            new() { FieldName = "status", DataType = AttributeDataType.String }
+        };
+
+        // Act
+        var cut = RenderWithMud<FeatureAttributesControl>(parameters => parameters
+            .Add(p => p.SelectedFeatures, features)
+            .Add(p => p.EditableFieldsConfig, editableFields));
+
+        // Assert - should show "active" since both features have the same value
+        cut.Markup.Should().Contain("status");
+        cut.Markup.Should().Contain("active");
+    }
+
+    [Fact]
+    public void FeatureAttributesControl_MultiEdit_ShowsDifferentValuesPlaceholder()
+    {
+        // Arrange
+        var feature1Json = """{"type": "Feature", "properties": {"name": "Feature One"}}""";
+        var feature2Json = """{"type": "Feature", "properties": {"name": "Feature Two"}}""";
+        
+        var features = new List<SelectedFeature>
+        {
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature1Json) },
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature2Json) }
+        };
+
+        var editableFields = new List<AttributeFieldConfig>
+        {
+            new() { FieldName = "name", DataType = AttributeDataType.String }
+        };
+
+        // Act
+        var cut = RenderWithMud<FeatureAttributesControl>(parameters => parameters
+            .Add(p => p.SelectedFeatures, features)
+            .Add(p => p.EditableFieldsConfig, editableFields)
+            .Add(p => p.IsLocked, false));
+
+        // Assert - should show "(Different values)" placeholder or text
+        cut.Markup.Should().Contain("(Different values)");
+    }
+
+    [Fact]
+    public void FeatureAttributesControl_MultiEdit_AllowsEditing()
+    {
+        // Arrange
+        var feature1Json = """{"type": "Feature", "properties": {"value": 10}}""";
+        var feature2Json = """{"type": "Feature", "properties": {"value": 20}}""";
+        
+        var features = new List<SelectedFeature>
+        {
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature1Json) },
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature2Json) }
+        };
+
+        var editableFields = new List<AttributeFieldConfig>
+        {
+            new() { FieldName = "value", DataType = AttributeDataType.Integer, IsReadOnly = false }
+        };
+
+        // Act
+        var cut = RenderWithMud<FeatureAttributesControl>(parameters => parameters
+            .Add(p => p.SelectedFeatures, features)
+            .Add(p => p.EditableFieldsConfig, editableFields)
+            .Add(p => p.IsLocked, false));
+
+        // Assert - should show "(Different values)" text initially (not an input control)
+        cut.Markup.Should().Contain("(Different values)", "should show different values text before clicking");
+        cut.Markup.Should().NotContain("mud-input-slot", "should not show input control until field is clicked");
+        
+        // Click on the field to enter edit mode
+        var clickableDiv = cut.Find("div[style*='cursor: pointer']");
+        clickableDiv.Click();
+        
+        // Assert - should now render editable control after click
+        cut.Markup.Should().Contain("mud-input-slot", "should render an input control after clicking the field");
+    }
+
+    [Fact]
+    public void FeatureAttributesControl_MultiEdit_LockedState_PreventsEditing()
+    {
+        // Arrange
+        var feature1Json = """{"type": "Feature", "properties": {"name": "F1"}}""";
+        var feature2Json = """{"type": "Feature", "properties": {"name": "F2"}}""";
+        
+        var features = new List<SelectedFeature>
+        {
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature1Json) },
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature2Json) }
+        };
+
+        var editableFields = new List<AttributeFieldConfig>
+        {
+            new() { FieldName = "name", DataType = AttributeDataType.String }
+        };
+
+        // Act
+        var cut = RenderWithMud<FeatureAttributesControl>(parameters => parameters
+            .Add(p => p.SelectedFeatures, features)
+            .Add(p => p.EditableFieldsConfig, editableFields)
+            .Add(p => p.IsLocked, true));
+
+        // Assert - should show locked indicator and not show save button
+        cut.Markup.Should().Contain("Locked");
+        cut.Markup.Should().NotContain("Save Changes");
+    }
+
+    [Fact]
+    public void FeatureAttributesControl_MultiEdit_HandlesAllNullValues()
+    {
+        // Arrange
+        var feature1Json = """{"type": "Feature", "properties": {"optional": null}}""";
+        var feature2Json = """{"type": "Feature", "properties": {"optional": null}}""";
+        
+        var features = new List<SelectedFeature>
+        {
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature1Json) },
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature2Json) }
+        };
+
+        var editableFields = new List<AttributeFieldConfig>
+        {
+            new() { FieldName = "optional", DataType = AttributeDataType.String }
+        };
+
+        // Act
+        var cut = RenderWithMud<FeatureAttributesControl>(parameters => parameters
+            .Add(p => p.SelectedFeatures, features)
+            .Add(p => p.EditableFieldsConfig, editableFields));
+
+        // Assert - should display the field but with empty value (all null is treated as common value)
+        cut.Markup.Should().Contain("optional");
+    }
+
+    [Fact]
+    public void FeatureAttributesControl_MultiEdit_ShowsFieldsFromAllFeatures()
+    {
+        // Arrange - feature1 has "name", feature2 has "value", neither has both
+        var feature1Json = """{"type": "Feature", "properties": {"name": "Feature 1"}}""";
+        var feature2Json = """{"type": "Feature", "properties": {"value": 42}}""";
+        
+        var features = new List<SelectedFeature>
+        {
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature1Json) },
+            new() { LayerId = "layer1", Feature = JsonSerializer.Deserialize<JsonElement>(feature2Json) }
+        };
+
+        var editableFields = new List<AttributeFieldConfig>
+        {
+            new() { FieldName = "name", DataType = AttributeDataType.String },
+            new() { FieldName = "value", DataType = AttributeDataType.Integer }
+        };
+
+        // Act
+        var cut = RenderWithMud<FeatureAttributesControl>(parameters => parameters
+            .Add(p => p.SelectedFeatures, features)
+            .Add(p => p.EditableFieldsConfig, editableFields));
+
+        // Assert - should display both fields even though each feature is missing one
+        cut.Markup.Should().Contain("name", "should show 'name' field from feature1");
+        cut.Markup.Should().Contain("value", "should show 'value' field from feature2");
+    }
 }
+
+

--- a/tests/PyroGeoBlazor.DeckGL.Tests.Unit/Models/MultiFeatureEditContextTests.cs
+++ b/tests/PyroGeoBlazor.DeckGL.Tests.Unit/Models/MultiFeatureEditContextTests.cs
@@ -1,0 +1,194 @@
+namespace PyroGeoBlazor.DeckGL.Tests.Unit.Models;
+
+using FluentAssertions;
+
+using PyroGeoBlazor.DeckGL.Models;
+
+using System.Text.Json;
+
+public class MultiFeatureEditContextTests
+{
+    [Fact]
+    public void MultiFeatureEditContext_InitializesWithEmptyState()
+    {
+        // Arrange & Act
+        var context = new MultiFeatureEditContext();
+
+        // Assert
+        context.Features.Should().BeEmpty();
+        context.FieldStates.Should().BeEmpty();
+        context.CurrentValues.Should().BeEmpty();
+        context.ValidationErrors.Should().BeEmpty();
+        context.IsDirty.Should().BeFalse();
+        context.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MultiFeatureEditContext_SetCurrentValue_MarksAsDirty()
+    {
+        // Arrange
+        var context = new MultiFeatureEditContext();
+
+        // Act
+        context.SetCurrentValue("testField", "newValue");
+
+        // Assert
+        context.IsDirty.Should().BeTrue();
+        context.ModifiedFields.Should().Contain("testField");
+        context.GetCurrentValue("testField").Should().Be("newValue");
+    }
+
+    [Fact]
+    public void MultiFeatureEditContext_SetValidationError_MarksAsInvalid()
+    {
+        // Arrange
+        var context = new MultiFeatureEditContext();
+
+        // Act
+        context.SetValidationError("testField", "Field is required");
+
+        // Assert
+        context.IsValid.Should().BeFalse();
+        context.ValidationErrors.Should().ContainKey("testField");
+        context.ValidationErrors["testField"].Should().Be("Field is required");
+    }
+
+    [Fact]
+    public void MultiFeatureEditContext_ClearValidationError_RemovesError()
+    {
+        // Arrange
+        var context = new MultiFeatureEditContext();
+        context.SetValidationError("testField", "Error message");
+
+        // Act
+        context.ClearValidationError("testField");
+
+        // Assert
+        context.IsValid.Should().BeTrue();
+        context.ValidationErrors.Should().NotContainKey("testField");
+    }
+
+    [Fact]
+    public void MultiFeatureEditContext_ResetAll_ClearsModifications()
+    {
+        // Arrange
+        var context = new MultiFeatureEditContext();
+        context.SetCurrentValue("field1", "value1");
+        context.SetCurrentValue("field2", "value2");
+        context.SetValidationError("field1", "Error");
+
+        // Act
+        context.ResetAll();
+
+        // Assert
+        context.IsDirty.Should().BeFalse();
+        context.IsValid.Should().BeTrue();
+        context.CurrentValues.Should().BeEmpty();
+        context.ValidationErrors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MultiFeatureEditContext_GetDisplayValue_ShowsDifferentValuesText()
+    {
+        // Arrange
+        var context = new MultiFeatureEditContext();
+        context.FieldStates["testField"] = new FieldValueState
+        {
+            HasDifferentValues = true,
+            CommonValue = null
+        };
+
+        // Act
+        var displayValue = context.GetDisplayValue("testField");
+
+        // Assert
+        displayValue.Should().Be("(Different values)");
+    }
+
+    [Fact]
+    public void MultiFeatureEditContext_GetDisplayValue_ShowsCommonValue()
+    {
+        // Arrange
+        var context = new MultiFeatureEditContext();
+        context.FieldStates["testField"] = new FieldValueState
+        {
+            HasDifferentValues = false,
+            CommonValue = "SharedValue"
+        };
+
+        // Act
+        var displayValue = context.GetDisplayValue("testField");
+
+        // Assert
+        displayValue.Should().Be("SharedValue");
+    }
+
+    [Fact]
+    public void MultiFeatureEditContext_GetDisplayValue_ShowsModifiedValue()
+    {
+        // Arrange
+        var context = new MultiFeatureEditContext();
+        context.FieldStates["testField"] = new FieldValueState
+        {
+            HasDifferentValues = true,
+            CommonValue = null
+        };
+        context.SetCurrentValue("testField", "ModifiedValue");
+
+        // Act
+        var displayValue = context.GetDisplayValue("testField");
+
+        // Assert
+        displayValue.Should().Be("ModifiedValue", "modified value should take precedence");
+    }
+
+    [Fact]
+    public void FieldValueState_CorrectlyIdentifiesAllNull()
+    {
+        // Arrange & Act
+        var state = new FieldValueState
+        {
+            AllNull = true,
+            HasDifferentValues = false,
+            CommonValue = null
+        };
+
+        // Assert
+        state.AllNull.Should().BeTrue();
+        state.HasDifferentValues.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FieldValueState_CorrectlyIdentifiesCommonValue()
+    {
+        // Arrange & Act
+        var state = new FieldValueState
+        {
+            AllNull = false,
+            HasDifferentValues = false,
+            CommonValue = 42
+        };
+
+        // Assert
+        state.AllNull.Should().BeFalse();
+        state.HasDifferentValues.Should().BeFalse();
+        state.CommonValue.Should().Be(42);
+    }
+
+    [Fact]
+    public void FieldValueState_CorrectlyIdentifiesDifferentValues()
+    {
+        // Arrange & Act
+        var state = new FieldValueState
+        {
+            AllNull = false,
+            HasDifferentValues = true,
+            CommonValue = null
+        };
+
+        // Assert
+        state.AllNull.Should().BeFalse();
+        state.HasDifferentValues.Should().BeTrue();
+        state.CommonValue.Should().BeNull();
+    }
+}

--- a/tests/PyroGeoBlazor.DeckGL.Tests.Unit/MudBlazorTestContext.cs
+++ b/tests/PyroGeoBlazor.DeckGL.Tests.Unit/MudBlazorTestContext.cs
@@ -23,6 +23,7 @@ public abstract class MudBlazorTestContext : BunitContext, IAsyncDisposable
         JSInterop.SetupVoid("mudPopover.connect", _ => true);
         JSInterop.SetupVoid("mudKeyInterceptor.connect", _ => true);
         JSInterop.SetupVoid("mudDragAndDrop.initDropZone", _ => true);
+        JSInterop.SetupVoid("mudElementRef.addOnBlurEvent", _ => true);
         JSInterop.Setup<int>("mudpopoverHelper.countProviders").SetResult(0);
     }
 


### PR DESCRIPTION
Enable multi-feature selection & batch attribute editing

- Add Ctrl+click and layer header click for multi-selection (single layer only) in FeatureSelectionControl
- Implement batch attribute editing in FeatureAttributesControl, showing all unique fields and handling differing values
- Add MultiFeatureEditContext and FieldValueState for batch edit state tracking
- Update JS interop to track full feature data for robust selection/unselection
- Improve UI: flat feature list, visual multi-select indicators, "(Different values)" editing
- Extend validation, save/reset logic, and event callbacks for multi-edit mode
- Add comprehensive unit tests for multi-edit and selection logic
- Update changelog and ensure valid CSS for selection highlighting